### PR TITLE
Switching sides on the diff to correct Jenkins' display

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mailwatcher/jobConfigHistory/ConfigHistory.java
+++ b/src/main/java/org/jenkinsci/plugins/mailwatcher/jobConfigHistory/ConfigHistory.java
@@ -55,7 +55,7 @@ public class ConfigHistory {
 
         return String.format(
                 "%sjobConfigHistory/showDiffFiles?timestamp1=%s&timestamp2=%s",
-                job.getShortUrl(), configs.get(0).getDate(), configs.get(1).getDate()
+                job.getShortUrl(), configs.get(1).getDate(), configs.get(0).getDate()
         );
     }
 

--- a/src/test/java/org/jenkinsci/plugins/mailwatcher/jobConfigHistory/ConfigHistoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mailwatcher/jobConfigHistory/ConfigHistoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.mailwatcher.jobConfigHistory;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import hudson.model.Job;
+import hudson.plugins.jobConfigHistory.ConfigInfo;
+import hudson.plugins.jobConfigHistory.JobConfigHistory;
+import hudson.plugins.jobConfigHistory.JobConfigHistoryProjectAction;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * @since November 12, 2014
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(JobConfigHistoryProjectAction.class)
+public class ConfigHistoryTest {
+    static final String DATE_1 = "date1";
+    static final String DATE_2 = "date2";
+    static final String SHORT_URL = "http://shorturl.com/";
+    @Mock ConfigInfo configInfo1;
+    @Mock ConfigInfo configInfo2;
+    @Mock Job job;
+    @Mock JobConfigHistory jobConfigHistory;
+    @Mock JobConfigHistoryProjectAction jobConfigHistoryProjectAction;
+
+    @Before public void setup() {
+        when(configInfo1.getDate()).thenReturn(DATE_1);
+        when(configInfo2.getDate()).thenReturn(DATE_2);
+    }
+
+    private ConfigHistory make(JobConfigHistory plugin) {
+        return new ConfigHistory(plugin);
+    }
+
+    private ConfigHistory make() {
+        return make(jobConfigHistory);
+    }
+
+    @Test public void testLastChangeDiffUrlNull() {
+        assertNull(make(null).lastChangeDiffUrl(job));
+    }
+
+    @Test public void testLastChangeDiffUrl() throws Exception {
+        when(job.getAction(JobConfigHistoryProjectAction.class)).thenReturn(jobConfigHistoryProjectAction);
+        doReturn(SHORT_URL).when(job).getShortUrl();
+        doReturn(newArrayList(configInfo2, configInfo1)).when(jobConfigHistoryProjectAction).getJobConfigs();
+        assertEquals(SHORT_URL + "jobConfigHistory/showDiffFiles?timestamp1=date1&timestamp2=date2",
+                make().lastChangeDiffUrl(job));
+    }
+}


### PR DESCRIPTION
This plugin sent me this link, which produced a diff that showed the opposite of reality.  This fixes the ordering of timestamps in the URL _and_ adds tests.

http://jenkinshost/job/job/jobConfigHistory/showDiffFiles?timestamp1=2014-11-12_08-35-40&timestamp2=2014-11-12_08-35-39