### PR TITLE
[JENKINS-69831] No notification on offline/online node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   <properties>
     <revision>1.18</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.332.1</jenkins.version>
+    <jenkins.version>2.346.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
     <mockito.version>3.12.4</mockito.version>
     <powermock.version>2.0.9</powermock.version>
@@ -49,7 +49,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-2.346.x</artifactId>
         <version>1556.vfc6a_f216e3c6</version>
         <scope>import</scope>
         <type>pom</type>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jobConfigHistory</artifactId>
-      <version>1139.v888b_656ca_f6d</version>
+      <version>1176.v1b_4290db_41a_5</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/mailwatcher/MailWatcherMailer.java
+++ b/src/main/java/org/jenkinsci/plugins/mailwatcher/MailWatcherMailer.java
@@ -23,7 +23,6 @@
  */
 package org.jenkinsci.plugins.mailwatcher;
 
-import hudson.Plugin;
 import hudson.model.User;
 import hudson.plugins.jobConfigHistory.JobConfigHistory;
 import hudson.tasks.Mailer;
@@ -42,6 +41,7 @@ import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 
+import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 
 import org.jenkinsci.plugins.mailwatcher.jobConfigHistory.ConfigHistory;
@@ -63,7 +63,7 @@ public class MailWatcherMailer {
 
         this.jenkins = jenkins;
         this.mailerDescriptor = jenkins.getDescriptorByType(Mailer.DescriptorImpl.class);
-        this.configHistory = new ConfigHistory((JobConfigHistory) plugin("jobConfigHistory"));
+        this.configHistory = new ConfigHistory(plugin(JobConfigHistory.class));
     }
 
     /*package*/ @Nonnull User getDefaultInitiator() {
@@ -75,9 +75,9 @@ public class MailWatcherMailer {
         ;
     }
 
-    /*package*/ @CheckForNull Plugin plugin(final String plugin) {
+    /*package*/ @CheckForNull <GC extends GlobalConfiguration> GC plugin(final @Nonnull Class<GC> clazz) {
 
-        return jenkins.getPlugin(plugin);
+        return GlobalConfiguration.all().get(clazz);
     }
 
     /*package*/ @Nonnull URL absoluteUrl(final @Nonnull String url) {

--- a/src/test/java/org/jenkinsci/plugins/mailwatcher/WatcherItemListenerWithJobConfigHistoryPluginTest.java
+++ b/src/test/java/org/jenkinsci/plugins/mailwatcher/WatcherItemListenerWithJobConfigHistoryPluginTest.java
@@ -92,7 +92,7 @@ public class WatcherItemListenerWithJobConfigHistoryPluginTest extends WatcherIt
     private void givenJobConfigHistoryPlugin() {
 
         final JobConfigHistory plugin = mock(JobConfigHistory.class);
-        when(mailer.plugin("jobConfigHistory")).thenReturn(plugin);
+        when(mailer.plugin(JobConfigHistory.class)).thenReturn(plugin);
 
         when(mailer.configHistory()).thenReturn(new ConfigHistory(plugin));
     }


### PR DESCRIPTION
See [JENKINS-69831](https://issues.jenkins.io/browse/JENKINS-69831). Adapts to the breaking changes introduced in https://github.com/jenkinsci/job-config-history-plugin/pull/237. To test this I reproduced the failure locally and confirmed the failure no longer occurred after this PR. Note that I am no longer a maintainer of this plugin, but I left it up for adoption the last time I touched it. @Dohbedoh are you interested in adopting this plugin to merge and release this fix as a follow-up to https://github.com/jenkinsci/job-config-history-plugin/pull/237?