### PR TITLE
Fix compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.59</version>
+    <version>4.45</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jobConfigHistory</artifactId>
-      <version>1206.vc8967cc8a_2cb_</version>
+      <version>1176.v1b_4290db_41a_5</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Fix compilation by reverting two commits

Compilation fails on ci.jenkins.io and in my development environment without these changes.

- Revert "Bump plugin from 4.45 to 4.55"
- Revert "Bump jobConfigHistory from 1176.v1b_4290db_41a_5 to 1206.vc8967cc8a_2cb_"

### Testing done

Confirmed that the plugin compiles with Java 8 and Java 11.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
