### PR TITLE
[JENKINS-75930] Mail watcher logs a stack trace if job config history plugin is not installed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/mailwatcher/MailWatcherMailer.java
+++ b/src/main/java/org/jenkinsci/plugins/mailwatcher/MailWatcherMailer.java
@@ -64,7 +64,8 @@ public class MailWatcherMailer {
 
         this.jenkins = jenkins;
         this.mailerDescriptor = jenkins.getDescriptorByType(Mailer.DescriptorImpl.class);
-        this.configHistory = new ConfigHistory(plugin(JobConfigHistory.class));
+        var p = jenkins.pluginManager.getPlugin("jobConfigHistory");
+        this.configHistory = new ConfigHistory(p != null && p.isActive() ? plugin(JobConfigHistory.class) : null);
     }
 
     /*package*/ @NonNull User getDefaultInitiator() {


### PR DESCRIPTION
## [JENKINS-75930] Mail watcher logs a stack trace if job config history plugin is not installed

The Job Configuration History plugin is an optional dependency of the Mail Watcher plugin.  Unfortunately, initialization of one of the classes of the Mail Watcher plugin fails if the Job Configuration History plugin is not available.

This change fixes the initialization so that it completes and assigns a null configHistory.

[JENKINS-75930](https://issues.jenkins.io/browse/JENKINS-75930) provides more details.

### Testing done

* Confirmed that automated tests pass
* Confirmed that I see the failure message when Jenkins starts with the released plugin
* Confirmed that the failure message does not appear with this change

### Detailed failure mode:

For detail purposes, the failure message that is logged to the Jenkins system log is :

```
2025-07-25 00:07:38.384+0000 [id=46]	WARNING	h.ExtensionFinder$GuiceFinder$FaultTolerantScope$1#error: Failed to instantiate Key[type=org.jenkinsci.plugins.mailwatcher.WatcherComputerListener, annotation=[none]]; skipping this component
java.lang.ClassNotFoundException: hudson.plugins.jobConfigHistory.JobConfigHistory
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
	at jenkins.util.URLClassLoader2.findClass(URLClassLoader2.java:64)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:593)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
Caused: java.lang.NoClassDefFoundError: hudson/plugins/jobConfigHistory/JobConfigHistory
	at PluginClassLoader for mail-watcher-plugin//org.jenkinsci.plugins.mailwatcher.MailWatcherMailer.<init>(MailWatcherMailer.java:67)
	at PluginClassLoader for mail-watcher-plugin//org.jenkinsci.plugins.mailwatcher.WatcherComputerListener.<init>(WatcherComputerListener.java:57)
	at PluginClassLoader for mail-watcher-plugin//org.jenkinsci.plugins.mailwatcher.WatcherComputerListener$$FastClassByGuice$$272ea3e5.GUICE$TRAMPOLINE(<generated>)
	at PluginClassLoader for mail-watcher-plugin//org.jenkinsci.plugins.mailwatcher.WatcherComputerListener$$FastClassByGuice$$272ea3e5.apply(<generated>)
	at com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:82)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:114)
	at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:33)
	at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:98)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:109)
	at hudson.ExtensionFinder$GuiceFinder$SezpozModule.onProvision(ExtensionFinder.java:613)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:117)
	at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:66)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:93)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:300)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
Caused: com.google.inject.ProvisionException: Unable to provision, see the following errors:

1) [Guice/ErrorInjectingConstructor]: NoClassDefFoundError: hudson/plugins/jobConfigHistory/JobConfigHistory
  at WatcherComputerListener.<init>(WatcherComputerListener.java:56)

Learn more:
  https://github.com/google/guice/wiki/ERROR_INJECTING_CONSTRUCTOR

1 error

======================
Full classname legend:
======================
WatcherComputerListener: "org.jenkinsci.plugins.mailwatcher.WatcherComputerListener"
========================
End of classname legend:
========================

	at com.google.inject.internal.InternalProvisionException.toProvisionException(InternalProvisionException.java:251)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:43)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169)
	at hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1.get(ExtensionFinder.java:448)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45)
	at com.google.inject.internal.InjectorImpl$1.get(InjectorImpl.java:1148)
	at hudson.ExtensionFinder$GuiceFinder._find(ExtensionFinder.java:406)
	at hudson.ExtensionFinder$GuiceFinder.find(ExtensionFinder.java:397)
	at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:353)
	at hudson.ExtensionList.load(ExtensionList.java:405)
	at hudson.ExtensionList.ensureLoaded(ExtensionList.java:324)
	at hudson.ExtensionList.iterator(ExtensionList.java:176)
	at jenkins.util.Listeners.lambda$notify$0(Listeners.java:57)
	at jenkins.util.Listeners.notify(Listeners.java:70)
	at hudson.model.AbstractCIBase.updateComputerList(AbstractCIBase.java:278)
	at jenkins.model.Jenkins.updateComputers(Jenkins.java:1617)
	at jenkins.model.Jenkins.load(Jenkins.java:3391)
	at jenkins.model.Jenkins$13.run(Jenkins.java:3484)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:175)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:304)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1151)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:221)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:120)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
2025-07-25 00:07:38.422+0000 [id=41]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
2025-07-25 00:07:38.422+0000 [id=45]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
2025-07-25 00:07:38.423+0000 [id=46]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
2025-07-25 00:07:38.433+0000 [id=40]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
2025-07-25 00:07:38.605+0000 [id=40]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
2025-07-25 00:07:38.626+0000 [id=33]	WARNING	h.ExtensionFinder$GuiceFinder$FaultTolerantScope$1#error: Failed to instantiate Key[type=org.jenkinsci.plugins.mailwatcher.WatcherItemListener, annotation=[none]]; skipping this component
java.lang.ClassNotFoundException: hudson.plugins.jobConfigHistory.JobConfigHistory
Caused: java.lang.NoClassDefFoundError: hudson/plugins/jobConfigHistory/JobConfigHistory
	at PluginClassLoader for mail-watcher-plugin//org.jenkinsci.plugins.mailwatcher.MailWatcherMailer.<init>(MailWatcherMailer.java:67)
	at PluginClassLoader for mail-watcher-plugin//org.jenkinsci.plugins.mailwatcher.WatcherItemListener.<init>(WatcherItemListener.java:57)
	at PluginClassLoader for mail-watcher-plugin//org.jenkinsci.plugins.mailwatcher.WatcherItemListener$$FastClassByGuice$$27305029.GUICE$TRAMPOLINE(<generated>)
	at PluginClassLoader for mail-watcher-plugin//org.jenkinsci.plugins.mailwatcher.WatcherItemListener$$FastClassByGuice$$27305029.apply(<generated>)
	at com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:82)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:114)
	at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:33)
	at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:98)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:109)
	at hudson.ExtensionFinder$GuiceFinder$SezpozModule.onProvision(ExtensionFinder.java:613)
	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:117)
	at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:66)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:93)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:300)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
Caused: com.google.inject.ProvisionException: Unable to provision, see the following errors:

1) [Guice/ErrorInjectingConstructor]: NoClassDefFoundError: hudson/plugins/jobConfigHistory/JobConfigHistory
  at WatcherItemListener.<init>(WatcherItemListener.java:56)

Learn more:
  https://github.com/google/guice/wiki/ERROR_INJECTING_CONSTRUCTOR

1 error

======================
Full classname legend:
======================
WatcherItemListener:  "org.jenkinsci.plugins.mailwatcher.WatcherItemListener"
========================
End of classname legend:
========================

	at com.google.inject.internal.InternalProvisionException.toProvisionException(InternalProvisionException.java:251)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:43)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169)
	at hudson.ExtensionFinder$GuiceFinder$FaultTolerantScope$1.get(ExtensionFinder.java:448)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45)
	at com.google.inject.internal.InjectorImpl$1.get(InjectorImpl.java:1148)
	at hudson.ExtensionFinder$GuiceFinder._find(ExtensionFinder.java:406)
	at hudson.ExtensionFinder$GuiceFinder.find(ExtensionFinder.java:397)
	at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:353)
	at hudson.ExtensionList.load(ExtensionList.java:405)
	at hudson.ExtensionList.ensureLoaded(ExtensionList.java:324)
	at hudson.ExtensionList.iterator(ExtensionList.java:176)
	at jenkins.model.Jenkins.<init>(Jenkins.java:1035)
	at hudson.model.Hudson.<init>(Hudson.java:102)
	at hudson.model.Hudson.<init>(Hudson.java:87)
	at hudson.WebAppMain$3.run(WebAppMain.java:249)
2025-07-25 00:07:38.629+0000 [id=33]	INFO	hudson.lifecycle.Lifecycle#onReady: Jenkins is fully up and running
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
